### PR TITLE
Update board.h

### DIFF
--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -146,12 +146,14 @@ uint32_t isBootloaderStart(const uint8_t * buffer);
 void SDRAM_Init();
 
 // Pulses driver
-#if defined(RADIO_T18)
+#if defined(RADIO_T18) || defined(RADIO_T16)
 
-// TX18S Workaround (see https://github.com/EdgeTX/edgetx/issues/802):
+// MPM Power Supply Workaround
+// (see https://github.com/EdgeTX/edgetx/issues/802)
 //   Add some delay after turning the internal module ON
-//   on the T18 / TX18S, as the latter seems to have issues
-//   with power supply showing instability
+//   on T18, TX18S due to power supply instability
+//   (also affects some early T16 units: see
+//   https://github.com/EdgeTX/edgetx/issues/1239)
 //
 #define INTERNAL_MODULE_ON()                                  \
   do {                                                        \


### PR DESCRIPTION
Apply power-on delay for T18/TX18S internal module to T16 - see https://github.com/EdgeTX/edgetx/issues/1239

Please note that pull requests are NOT an appropriate way to ask questions or for support.

For feature request or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.
<!-- Please delete the above if not relevant, and any of the below which does not apply -->

Fixes #

Summary of changes:
